### PR TITLE
Optimize editor-toolbar to prevent constant rerenders

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tiptap/extension-highlight": "^3.2.0",
     "@tiptap/extension-underline": "^3.2.0",
     "@tiptap/extensions": "^3.2.0",
+    "@tiptap/pm": "^3.4.2",
     "@tiptap/react": "^3.1.0",
     "@tiptap/starter-kit": "^3.1.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@tiptap/extensions':
         specifier: ^3.2.0
         version: 3.4.2(@tiptap/core@3.4.2(@tiptap/pm@3.4.2))(@tiptap/pm@3.4.2)
+      '@tiptap/pm':
+        specifier: ^3.4.2
+        version: 3.4.2
       '@tiptap/react':
         specifier: ^3.1.0
         version: 3.4.2(@floating-ui/dom@1.7.4)(@tiptap/core@3.4.2(@tiptap/pm@3.4.2))(@tiptap/pm@3.4.2)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)


### PR DESCRIPTION
Previously, we were forcing a rerender on every transaction. I was doing this to try and force `toolbarItems` to be re-evaluated and update the states. This is quite bad... Fixed it here by rerendering only when we have an actual state change. 